### PR TITLE
Modify to build message in message

### DIFF
--- a/generator/client.go
+++ b/generator/client.go
@@ -327,8 +327,8 @@ func CreateClientAPI(d *descriptor.FileDescriptorProto, generator *generator.Gen
 
 	// Parse all Messages for generating typescript interfaces
 
-	var f func(ms []*descriptor.DescriptorProto)
-	f = func(ms []*descriptor.DescriptorProto) {
+	var addModel func(ms []*descriptor.DescriptorProto)
+	addModel = func(ms []*descriptor.DescriptorProto) {
 		for _, m := range ms {
 			if len(m.GetField()) == 2 &&
 				m.GetField()[0].GetName() == "key" &&
@@ -344,11 +344,11 @@ func CreateClientAPI(d *descriptor.FileDescriptorProto, generator *generator.Gen
 			}
 			ctx.AddModel(model)
 			if len(m.NestedType) != 0 {
-				f(m.NestedType)
+				addModel(m.NestedType)
 			}
 		}
 	}
-	f(d.GetMessageType())
+	addModel(d.GetMessageType())
 
 	// Parse all Services for generating typescript method interfaces and default client implementations
 	for _, s := range d.GetService() {

--- a/main.go
+++ b/main.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	"github.com/apptreesoftware/protoc-gen-twirp_dart/generator"
-	"github.com/gogo/protobuf/protoc-gen-gogo/plugin"
 	"io"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"github.com/apptreesoftware/protoc-gen-twirp_dart/generator"
+	"github.com/gogo/protobuf/protoc-gen-gogo/plugin"
 
 	gogogen "github.com/gogo/protobuf/protoc-gen-gogo/generator"
 	"github.com/golang/protobuf/proto"


### PR DESCRIPTION
fixed #1.

But, the message in the message is defined top-level because Dart is not supported inner class.

I think it is not work the following protobuf code...

``` proto
message A {
  message B { // ... (1)
    string b = 1;
  }
  B bb = 2;
}

message B {  // ... (2)
  string bbb = 1;
}
```

Maybe `message B`(1) will be overloaded as `message B`(2) .

Therefore I want to hear opinions of people familiar with Dart because I'm not too familiar with it...

Thx